### PR TITLE
fix: remove the language code from the nav bar

### DIFF
--- a/READE.md
+++ b/READE.md
@@ -10,5 +10,4 @@ hugo server -D
 
 ## TODO
 
-- [ ] Book + covers laten zien
-- [ ] Links zoeken van missende boeken
+- [ ] Optimize the images used on the site, they are not consistent

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -5,7 +5,6 @@
 
       <nav class="navbar navbar-expand-lg navbar-light fixed-top p-0">
         <div class="container">
-          {{ .Site.Language.Lang }}
           {{ if .Site.Params.logo }}
           <a class="navbar-brand fw-bold" href="{{ "" | absLangURL }}"><img src="{{.Site.Params.logo}}" alt="{{ .Site.Title }}" height="50px" /></a>
           {{ else }}


### PR DESCRIPTION
During some testing I added a language code to see what the actual value was. I forgot to remove this earlier.