### PR TITLE
feat: enable search

### DIFF
--- a/READE.md
+++ b/READE.md
@@ -11,4 +11,3 @@ hugo server -D
 ## TODO
 
 - [ ] Optimize the images used on the site, they are not consistent
-- [ ] Enable search function in the theme

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,6 +7,7 @@ defaultContentLanguage = "nl"
 
 [params]
   selfHosted = true
+  lunrSearch = true
   previewCardImagePlacement = "top"
   logo = "/images/logo.png"
   description = "Elke eerste XKE van de maand word er voor gelezen."


### PR DESCRIPTION
If you search on "ridder" it will find the Elsa edition. It only indexes the body of the pages not the frontmatters metadata. We might need to spent some time writing bodies for the editions?